### PR TITLE
PLAT-966: node pools should start at the minimum count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   addon_profile {
+    kube_dashboard {
+      enabled = false
+    }
+
     oms_agent {
       enabled                    = true
       log_analytics_workspace_id = azurerm_log_analytics_workspace.logs.id

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   default_node_pool {
     enable_node_public_ip = var.node_pools.platform.enable_node_public_ip
     name                  = "platform"
-    node_count            = var.node_pools.platform.max_count
+    node_count            = var.node_pools.platform.min_count
     node_labels           = merge({ "dominodatalab.com/node-pool" : "platform" }, var.node_pools.platform.node_labels)
     vm_size               = var.node_pools.platform.vm_size
     availability_zones    = var.node_pools.platform.zones
@@ -143,7 +143,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "aks" {
   enable_node_public_ip = each.value.enable_node_public_ip
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
   name                  = each.key
-  node_count            = each.value.max_count
+  node_count            = each.value.min_count
   vm_size               = each.value.vm_size
   availability_zones    = each.value.zones
   max_pods              = 250


### PR DESCRIPTION
When deploying on AKS, multiple nodes may be created in the same zone.
The scheduler will use all the available nodes. However, the autoscaler
may attempt to scale down. This can happen during a deploy. In some
unlucky situations, it can take minutes to re-attach disks when
switching nodes. Helm has a tendency to fail if it happens to be some
dependency like postgres or mongo.
To prevent such issues, we will do the opposite and scale up if needed.