### PR TITLE
update AKS network defaults and switch to azure network policy enforcement

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -51,12 +51,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
   }
 
   network_profile {
-    load_balancer_sku  = "Standard"
-    network_plugin     = "azure"
-    network_policy     = "calico"
-    dns_service_ip     = "100.97.0.10"
-    docker_bridge_cidr = "172.17.0.1/16"
-    service_cidr       = "100.97.0.0/16"
+    load_balancer_sku = "Standard"
+    network_plugin    = "azure"
+    network_policy    = "azure"
   }
 
   tags = local.tags


### PR DESCRIPTION
* Not a lot of reasons to explicitly override the AKS network defaults to the ones we use for Rancher / AWS
* Azure has native [network policy enforcement now](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#differences-between-azure-and-calico-policies-and-their-capabilities)