### PR TITLE
revert azure network policy setting

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -53,7 +53,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   network_profile {
     load_balancer_sku = "Standard"
     network_plugin    = "azure"
-    network_policy    = "azure"
+    network_policy    = "calico"
   }
 
   tags = local.tags


### PR DESCRIPTION
Azure's netpol enforcement apparently cannot differentiate host network
pods traffic from node traffic and this causes exec / logs issues.

ref: https://github.com/Azure/azure-container-networking/issues/723