### PR TITLE
allow configuration of kubernetes version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
       - run:
           name: Terraform init
-          command: terraform init
+          command: terraform init -backend-config=key=$WORKSPACE.tfstate
 
       - run:
           name: Terraform validate

--- a/aks.tf
+++ b/aks.tf
@@ -23,6 +23,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix              = local.cluster_name
   private_cluster_enabled = false
   sku_tier                = var.cluster_sku_tier
+  kubernetes_version      = var.kubernetes_version
 
   api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
 

--- a/aks.tf
+++ b/aks.tf
@@ -5,6 +5,12 @@ locals {
   }
 }
 
+data "azurerm_kubernetes_service_versions" "selected" {
+  location        = local.resource_group.location
+  version_prefix  = var.kubernetes_version
+  include_preview = false
+}
+
 resource "azurerm_kubernetes_cluster" "aks" {
   lifecycle {
     ignore_changes = [
@@ -23,7 +29,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix              = local.cluster_name
   private_cluster_enabled = false
   sku_tier                = var.cluster_sku_tier
-  kubernetes_version      = var.kubernetes_version
+  kubernetes_version      = var.kubernetes_version != null ? data.azurerm_kubernetes_service_versions.selected.latest_version : null
 
   api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
 

--- a/variables.tf
+++ b/variables.tf
@@ -143,3 +143,9 @@ variable "tags" {
   default     = {}
   description = "Tags to apply to resources"
 }
+
+variable "kubernetes_version" {
+  type        = string
+  default     = null
+  description = "Optional Kubernetes version to provision"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -147,5 +147,5 @@ variable "tags" {
 variable "kubernetes_version" {
   type        = string
   default     = null
-  description = "Optional Kubernetes version to provision"
+  description = "Optional Kubernetes version to provision. Allows partial input (e.g. 1.18) which is then chosen from azurerm_kubernetes_service_versions."
 }


### PR DESCRIPTION
This allows optional configuration of the Kubernetes version. If unspecified, the default is used.