### PR TITLE
PLAT-3291: kubeconfig is overwrites existing

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -77,7 +77,8 @@ resource "azurerm_kubernetes_cluster" "aks" {
       if ! az account show 2>/dev/null; then
         az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET -t $ARM_TENANT_ID
       fi
-      az aks get-credentials -f ${var.kubeconfig_output_path} -n ${var.cluster_name} -g ${data.azurerm_resource_group.aks.name}
+
+      az aks get-credentials --overwrite-existing -f ${var.kubeconfig_output_path} -n ${var.cluster_name} -g ${data.azurerm_resource_group.aks.name}
     EOF
   }
 }


### PR DESCRIPTION
If you happen to recreate AKS, creating the kubeconfig will fail if the
cluster is already defined.
Provide the --overwrite-existing to recreate the kubeconfig when necessary.