### PR TITLE
PLAT-5177 support aks k8s version 1.24(preview)

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -8,7 +8,7 @@ locals {
 data "azurerm_kubernetes_service_versions" "selected" {
   location        = data.azurerm_resource_group.aks.location
   version_prefix  = var.kubernetes_version
-  include_preview = false
+  include_preview = true
 }
 
 resource "azurerm_kubernetes_cluster" "aks" {


### PR DESCRIPTION
Adding support for AKS k8s versions on  `preview`  to support k8s version 1.24 which is preview at the moment

```bash
KubernetesVersion    Upgrades
-------------------  ------------------------
1.24.0(preview)      None available
1.23.8               1.24.0(preview)
1.23.5               1.23.8, 1.24.0(preview)
1.22.11              1.23.5, 1.23.8
1.22.6               1.22.11, 1.23.5, 1.23.8
1.21.14              1.22.6, 1.22.11
1.21.9               1.21.14, 1.22.6, 1.22.11
```