### PR TITLE
DOM-54278 Output oidc_issuer_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Please submit any feature enhancements, bug fixes, or ideas via pull requests or
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.40 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.45 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.40 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.45 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ No modules.
 | <a name="output_aks_identity"></a> [aks\_identity](#output\_aks\_identity) | AKS managed identity |
 | <a name="output_containers"></a> [containers](#output\_containers) | storage details |
 | <a name="output_domino_acr"></a> [domino\_acr](#output\_domino\_acr) | Azure Container Registry details |
+| <a name="output_oidc_issuer_url"></a> [oidc\_issuer\_url](#output\_oidc\_issuer\_url) | OIDC issuer url |
 | <a name="output_storage_account"></a> [storage\_account](#output\_storage\_account) | storage account |
 | <a name="output_workload_identities"></a> [workload\_identities](#output\_workload\_identities) | service identities |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.40 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.45 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | ~> 2.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.40 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.45 |
 
 ## Modules
 

--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -49,8 +49,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_flyte_controlplane_client_id"></a> [flyte\_controlplane\_client\_id](#output\_flyte\_controlplane\_client\_id) | Flyte controlplane client id |
-| <a name="output_flyte_data_container_name"></a> [flyte\_data\_container\_name](#output\_flyte\_data\_container\_name) | Flyte data storage container name |
-| <a name="output_flyte_dataplane_client_id"></a> [flyte\_dataplane\_client\_id](#output\_flyte\_dataplane\_client\_id) | Flyte dataplane client id |
-| <a name="output_flyte_metadata_container_name"></a> [flyte\_metadata\_container\_name](#output\_flyte\_metadata\_container\_name) | Flyte metadata storage container name |
+| <a name="output_controlplane_client_id"></a> [controlplane\_client\_id](#output\_controlplane\_client\_id) | Flyte controlplane client id |
+| <a name="output_data_container_name"></a> [data\_container\_name](#output\_data\_container\_name) | Flyte data storage container name |
+| <a name="output_dataplane_client_id"></a> [dataplane\_client\_id](#output\_dataplane\_client\_id) | Flyte dataplane client id |
+| <a name="output_metadata_container_name"></a> [metadata\_container\_name](#output\_metadata\_container\_name) | Flyte metadata storage container name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/flyte/outputs.tf
+++ b/modules/flyte/outputs.tf
@@ -1,19 +1,19 @@
-output "flyte_metadata_container_name" {
+output "metadata_container_name" {
   value       = azurerm_storage_container.flyte_metadata.name
   description = "Flyte metadata storage container name"
 }
 
-output "flyte_data_container_name" {
+output "data_container_name" {
   value       = azurerm_storage_container.flyte_data.name
   description = "Flyte data storage container name"
 }
 
-output "flyte_controlplane_client_id" {
+output "controlplane_client_id" {
   value       = azurerm_user_assigned_identity.this["flyte_controlplane"].client_id
   description = "Flyte controlplane client id"
 }
 
-output "flyte_dataplane_client_id" {
+output "dataplane_client_id" {
   value       = azurerm_user_assigned_identity.this["flyte_dataplane"].client_id
   description = "Flyte dataplane client id"
 }

--- a/modules/flyte/tests/README.md
+++ b/modules/flyte/tests/README.md
@@ -7,7 +7,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.40 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.45 |
 
 ## Providers
 

--- a/modules/flyte/tests/versions.tf
+++ b/modules/flyte/tests/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.40"
+      version = "~> 3.45"
     }
   }
 }

--- a/modules/flyte/versions.tf
+++ b/modules/flyte/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.40"
+      version = "~> 3.45"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "aks_identity" {
   value       = azurerm_kubernetes_cluster.aks.kubelet_identity[0]
 }
 
+output "oidc_issuer_url" {
+  description = "OIDC issuer url"
+  value       = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+}
+
 output "domino_acr" {
   description = "Azure Container Registry details"
   value       = azurerm_container_registry.domino

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.40 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.45 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.40 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.45 |
 
 ## Modules
 

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.40"
+      version = "~> 3.45"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.40"
+      version = "~> 3.45"
     }
 
     random = {


### PR DESCRIPTION
### What problem does this PR solve?
Provide Flyte access to the OIDC issuer url from `azurerm_kubernetes_cluster`

### What is the solution?
- Add `oidc_issuer_url` as an AKS output

#### Other changes:
- Bump azurerm required version to 3.45 due to https://github.com/hashicorp/terraform-provider-azurerm/issues/20623
- Rename Flyte output attributes

### Testing
Successfully provisioned Azure resources in a `dev-azure-aks` deploy:
```
# Add the following two lines to resources/deployer/manifests/dev-azure-aks.yaml manifest to enable Flyte
flyte:
  enabled: true

$ export DEPLOY_ID=po-flyte1

$ bin/domino-deployment terraform provision $DEPLOY_ID --var-file resources/deployer/manifests/dev-azure-aks.yaml --dry
2024-03-12 17:31:12,102 - INFO - domino.deployer.provisioner - Provision dry run successful.

$ bin/domino-deployment terraform provision $DEPLOY_ID
2024-03-12 17:41:44,049 - INFO - domino.deployer.provisioner - Provision successful. See terraform.output for IP addresses and other relevant data.
2024-03-12 17:41:44,049 - INFO - domino.deployer.provisioner - Main frontend: https://po-flyte1.az.domino.tech
2024-03-12 17:41:44,049 - INFO - domino.deployer.provisioner - Next steps:
2024-03-12 17:41:44,049 - INFO - domino.deployer.provisioner -  Install domino onto provisioned resources: `bin/domino-deployment install run po-flyte1`
2024-03-12 17:41:44,049 - INFO - domino.deployer.provisioner -  Destroy provisioned resources: `bin/domino-deployment terraform destroy po-flyte1`
```

### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-54278

Related PRs:
- https://github.com/dominodatalab/terraform-azure-aks/pull/46
- https://github.com/cerebrotech/platform-apps/pull/8794

