### PR TITLE
DOM-54281 Enable hierarchical namespace in storage account

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -8,6 +8,7 @@ resource "azurerm_storage_account" "domino" {
   access_tier              = "Hot"
   min_tls_version          = "TLS1_2"
   tags                     = var.tags
+  is_hns_enabled           = true
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
### What problem does this PR solve?
Enable hierarchical namespace in storage account to support directory level access for user delegation shared access signatures

[Discuss Azure Blob Storage Options / Upgrades](https://www.google.com/calendar/event?eid=NjVlbWw2YmYzMHY0ZjRoMGJ2bWZ0aGh0bjUgZXRoYW4uYnJvd25AZG9taW5vZGF0YWxhYi5jb20)

### What is the solution?
- Set `is_hns_enabled` to true

The `test-upgrade` CI step failed as expected because the change would force a new resource to be created.
> [is_hns_enabled](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account#is_hns_enabled) - (Optional) Is Hierarchical Namespace enabled? This can be used with Azure Data Lake Storage Gen 2 ([see here for more information](https://docs.microsoft.com/azure/storage/blobs/data-lake-storage-quickstart-create-account/)). Changing this forces a new resource to be created.

#### Notes
- With this PR, new deploys will have hierarchical namespace enabled as desired
- Existing deploys would require the storage account to be upgraded before upgrading Domino


### Testing
Provisioning successful:
```
$ bin/domino-deployment terraform provision $DEPLOY_ID --var-file resources/deployer/manifests/dev-azure-aks.yaml
...
2024-03-21 13:17:15,513 - Provision successful. See terraform.output for IP addresses and other relevant data.
2024-03-21 13:17:15,513 - Main frontend: https://potest1.az.domino.tech
```
Checking `isHnsEnabled` property for storage account:
```
$ az storage account show --name $DEPLOY_ID | jq '.isHnsEnabled'
true
```

### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-54281
