### PR TITLE
DOM-54281 Make flyteadmin act as dataplane

### DIFF
--- a/modules/flyte/identities.tf
+++ b/modules/flyte/identities.tf
@@ -1,7 +1,7 @@
 locals {
   # Kubernetes service account to user-assigned managed identity mapping
   federated_identity_mapping = {
-    flyteadmin     = azurerm_user_assigned_identity.flyte_controlplane.id
+    flyteadmin     = azurerm_user_assigned_identity.flyte_dataplane.id
     flytepropeller = azurerm_user_assigned_identity.flyte_controlplane.id
     datacatalog    = azurerm_user_assigned_identity.flyte_controlplane.id
     nucleus        = azurerm_user_assigned_identity.flyte_dataplane.id


### PR DESCRIPTION
### What problem does this PR solve?
Make flyteadmin act as dataplane because it has to be able to generate pre-signed urls for the data container.

### What is the solution?
Update federated_identity_mapping  to map `flyteadmin` to `flyte_dataplane` user-assigned identity.

### Testing

- Successfully provisioned Azure resources in a `dev-azure-aks` deploy
- Verified in the Azure portal that the `flyte-dataplane` managed identity has a federated credential for  `flyteadmin`

### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-54281

Related PRs:
- https://github.com/cerebrotech/platform-apps/pull/8877

