### PR TITLE
DOM-56630 Output Flyte storage account name and key

### DIFF
--- a/modules/flyte/README.md
+++ b/modules/flyte/README.md
@@ -56,4 +56,6 @@ No modules.
 | <a name="output_data_container_name"></a> [data\_container\_name](#output\_data\_container\_name) | Flyte data storage container name |
 | <a name="output_dataplane_client_id"></a> [dataplane\_client\_id](#output\_dataplane\_client\_id) | Flyte dataplane client id |
 | <a name="output_metadata_container_name"></a> [metadata\_container\_name](#output\_metadata\_container\_name) | Flyte metadata storage container name |
+| <a name="output_storage_account_key"></a> [storage\_account\_key](#output\_storage\_account\_key) | Flyte storage account key |
+| <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | Flyte storage account name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/flyte/outputs.tf
+++ b/modules/flyte/outputs.tf
@@ -17,3 +17,14 @@ output "dataplane_client_id" {
   value       = azurerm_user_assigned_identity.flyte_dataplane.client_id
   description = "Flyte dataplane client id"
 }
+
+output "storage_account_name" {
+  description = "Flyte storage account name"
+  value       = azurerm_storage_account.flyte.name
+}
+
+output "storage_account_key" {
+  description = "Flyte storage account key"
+  value       = azurerm_storage_account.flyte.primary_access_key
+  sensitive   = true
+}

--- a/modules/flyte/tests/outputs.tftest.hcl
+++ b/modules/flyte/tests/outputs.tftest.hcl
@@ -12,4 +12,9 @@ run "test_outputs" {
     condition     = output.data_container_name == azurerm_storage_container.flyte_data.name
     error_message = "Incorrect Flyte data container name output"
   }
+
+  assert {
+    condition     = output.storage_account_name == azurerm_storage_account.flyte.name
+    error_message = "Incorrect Flyte storage account name output"
+  }
 }


### PR DESCRIPTION
### What problem does this PR solve?
The Flyte storage containers `flyte-metadata` and `flyte-data` must be configured to use the Flyte storage account, instead of the default storage account.

### What is the solution?
- Output the Flyte storage account name and key
- Add unit test

### Testing
Successfully provisioned a `dev-azure-aks` deploy with the storage containers using the correct storage account `potest1flyte`

agent.yaml
```
flyte:
  metadata_storage:
    azure:
      account_name: potest1flyte
      account_key: qsauQzYX+RVNQuG8lsm7OXJH69OGrTA2uNDMlfI/zAKIaLeMLy1OhRo2REbc6l6fLPzpb+MFG2gT+AStBliuUg==
      container: potest1-flyte-metadata
  data_storage:
    azure:
      account_name: potest1flyte
      account_key: qsauQzYX+RVNQuG8lsm7OXJH69OGrTA2uNDMlfI/zAKIaLeMLy1OhRo2REbc6l6fLPzpb+MFG2gT+AStBliuUg==
      container: potest1-flyte-data
```

### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-56630

Related PR:
https://github.com/cerebrotech/platform-apps/pull/8936
