### PR TITLE
DOM-56892 Add CORS rule to Flyte storage account

### DIFF
--- a/modules/flyte/storage.tf
+++ b/modules/flyte/storage.tf
@@ -10,6 +10,15 @@ resource "azurerm_storage_account" "flyte" {
   tags                     = var.tags
   is_hns_enabled           = true
 
+  blob_properties {
+    cors_rule {
+      allowed_headers    = ["x-ms-*"]
+      allowed_methods    = ["GET", "HEAD"]
+      allowed_origins    = ["*"]
+      exposed_headers    = [""]
+      max_age_in_seconds = 300
+    }
+  }
   lifecycle {
     ignore_changes = [
       tags

--- a/modules/flyte/tests/storage.tftest.hcl
+++ b/modules/flyte/tests/storage.tftest.hcl
@@ -37,4 +37,24 @@ run "test_storage" {
     condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].max_age_in_seconds == 300
     error_message = "Incorrect max age in Flyte CORS rule"
   }
+
+  assert {
+    condition     = azurerm_storage_container.flyte_metadata.name == "${var.deploy_id}-flyte-metadata"
+    error_message = "Incorrect flyte-metadata storage container name"
+  }
+
+  assert {
+    condition     = azurerm_storage_container.flyte_metadata.storage_account_name == azurerm_storage_account.flyte.name
+    error_message = "Incorrect storage account name for flyte-metadata storage container"
+  }
+
+  assert {
+    condition     = azurerm_storage_container.flyte_data.name == "${var.deploy_id}-flyte-data"
+    error_message = "Incorrect flyte-data storage container name"
+  }
+
+  assert {
+    condition     = azurerm_storage_container.flyte_data.storage_account_name == azurerm_storage_account.flyte.name
+    error_message = "Incorrect storage account name for flyte-data storage container"
+  }
 }

--- a/modules/flyte/tests/storage.tftest.hcl
+++ b/modules/flyte/tests/storage.tftest.hcl
@@ -1,0 +1,40 @@
+mock_provider "azurerm" {}
+
+run "test_storage" {
+  command = plan
+
+  assert {
+    condition     = azurerm_storage_account.flyte.name == "test12345flyte"
+    error_message = "Incorrect Flyte storage account name"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].allowed_headers[0] == "x-ms-*"
+    error_message = "Incorrect allowed headers for Flyte CORS rule"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].allowed_methods[0] == "GET"
+    error_message = "Incorrect allowed methods in Flyte CORS rule"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].allowed_methods[1] == "HEAD"
+    error_message = "Incorrect allowed methods in Flyte CORS rule"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].allowed_origins[0] == "*"
+    error_message = "Incorrect allowed origins in Flyte CORS rule"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].exposed_headers[0] == ""
+    error_message = "Incorrect exposed headers in Flyte CORS rule"
+  }
+
+  assert {
+    condition     = azurerm_storage_account.flyte.blob_properties[0].cors_rule[0].max_age_in_seconds == 300
+    error_message = "Incorrect max age in Flyte CORS rule"
+  }
+}

--- a/modules/flyte/tests/terraform.tfvars
+++ b/modules/flyte/tests/terraform.tfvars
@@ -1,4 +1,4 @@
-deploy_id               = "test12345"
+deploy_id               = "test-12345"
 oidc_issuer_url         = "https://westus2.oic.prod-aks.azure.com/e8b9c032-af3d-48f0-946e-7a1d84f2c569/6fbda7e8-9c54-42b2-ae1f-3d90e7cf4a28/"
 resource_group_location = "westus2"
-resource_group_name     = "test12345"
+resource_group_name     = "test-12345"


### PR DESCRIPTION
### What problem does this PR solve?
Unable to display workflow outputs due to CORS error

### What is the solution?
- Enable CORS in the Flyte storage account in Azure
- Add storage unit tests

### Testing
- Successfully provisioned a `dev-azure-aks` deploy with CORS enabled in the Flyte storage account

<img width="1501" alt="Screenshot 2024-04-24 at 10 32 42 PM" src="https://github.com/dominodatalab/terraform-azure-aks/assets/43554115/6c29e537-327a-453f-88cb-7ba17ddfbb9a">

- Checking CORS settings for the Flyte storage account via Azure CLI:

```
$ az storage blob service-properties show --account-name potest2flyte --auth-mode login
{
  "cors": [
    {
      "allowedHeaders": [
        "x-ms-*"
      ],
      "allowedMethods": [
        "GET",
        "HEAD"
      ],
      "allowedOrigins": [
        "*"
      ],
      "exposedHeaders": [],
      "maxAgeInSeconds": 300
    }
  ],
```

- Workflow outputs displayed correctly without CORS error

<img width="1582" alt="Screenshot 2024-04-24 at 10 52 25 PM" src="https://github.com/dominodatalab/terraform-azure-aks/assets/43554115/c7951355-67de-43ff-9e1a-15ac96d06a3b">


### Link to JIRA
https://dominodatalab.atlassian.net/browse/DOM-56892
https://github.com/cerebrotech/platform-apps/pull/8963


