### PR TITLE
PLAT-8394: Give importer access to ACR for migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ No modules.
 |------|------|
 | [azurerm_container_registry.domino](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry) | resource |
 | [azurerm_federated_identity_credential.hephaestus](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.importer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_kubernetes_cluster.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) | resource |
 | [azurerm_kubernetes_cluster_node_pool.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_log_analytics_solution.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_solution) | resource |

--- a/acr.tf
+++ b/acr.tf
@@ -1,4 +1,5 @@
 resource "azurerm_container_registry" "domino" {
+  #checkov:skip=CKV_AZURE_237: "Ensure dedicated data endpoints are enabled."
   name                = replace("${data.azurerm_resource_group.aks.name}domino", "/[^a-zA-Z0-9]/", "")
   resource_group_name = data.azurerm_resource_group.aks.name
   location            = data.azurerm_resource_group.aks.location

--- a/acr.tf
+++ b/acr.tf
@@ -30,3 +30,9 @@ resource "azurerm_role_assignment" "hephaestus_acr" {
   role_definition_name = "AcrPush"
   principal_id         = azurerm_user_assigned_identity.hephaestus.principal_id
 }
+
+resource "azurerm_role_assignment" "importer_acr" {
+  scope                = azurerm_container_registry.domino.id
+  role_definition_name = "AcrPush"
+  principal_id         = azurerm_user_assigned_identity.importer.principal_id
+}

--- a/acr.tf
+++ b/acr.tf
@@ -30,9 +30,3 @@ resource "azurerm_role_assignment" "hephaestus_acr" {
   role_definition_name = "AcrPush"
   principal_id         = azurerm_user_assigned_identity.hephaestus.principal_id
 }
-
-resource "azurerm_role_assignment" "importer_acr" {
-  scope                = azurerm_container_registry.domino.id
-  role_definition_name = "AcrPush"
-  principal_id         = azurerm_user_assigned_identity.importer.principal_id
-}

--- a/identities.tf
+++ b/identities.tf
@@ -13,3 +13,19 @@ resource "azurerm_federated_identity_credential" "hephaestus" {
   parent_id           = azurerm_user_assigned_identity.hephaestus.id
   subject             = "system:serviceaccount:${var.namespaces.compute}:hephaestus"
 }
+
+resource "azurerm_user_assigned_identity" "importer" {
+  name                = "importer"
+  location            = data.azurerm_resource_group.aks.location
+  resource_group_name = data.azurerm_resource_group.aks.name
+  tags                = var.tags
+}
+
+resource "azurerm_federated_identity_credential" "importer" {
+  name                = "importer"
+  resource_group_name = data.azurerm_resource_group.aks.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.importer.id
+  subject             = "system:serviceaccount:${var.namespaces.platform}:domino-data-importer"
+}

--- a/identities.tf
+++ b/identities.tf
@@ -14,18 +14,11 @@ resource "azurerm_federated_identity_credential" "hephaestus" {
   subject             = "system:serviceaccount:${var.namespaces.compute}:hephaestus"
 }
 
-resource "azurerm_user_assigned_identity" "importer" {
-  name                = "importer"
-  location            = data.azurerm_resource_group.aks.location
-  resource_group_name = data.azurerm_resource_group.aks.name
-  tags                = var.tags
-}
-
 resource "azurerm_federated_identity_credential" "importer" {
   name                = "importer"
   resource_group_name = data.azurerm_resource_group.aks.name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = azurerm_kubernetes_cluster.aks.oidc_issuer_url
-  parent_id           = azurerm_user_assigned_identity.importer.id
+  parent_id           = azurerm_user_assigned_identity.hephaestus.id
   subject             = "system:serviceaccount:${var.namespaces.platform}:domino-data-importer"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,5 @@ output "workload_identities" {
   description = "service identities"
   value = {
     "hephaestus" = azurerm_user_assigned_identity.hephaestus
-    "importer" = azurerm_user_assigned_identity.importer
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,5 +27,6 @@ output "workload_identities" {
   description = "service identities"
   value = {
     "hephaestus" = azurerm_user_assigned_identity.hephaestus
+    "importer" = azurerm_user_assigned_identity.importer
   }
 }


### PR DESCRIPTION
Currently, you need to setup ACR credentials manually, but it should be possible to determine them similar to heph. This allows the importer's service account to use the same workload identity and access ACR.